### PR TITLE
修改数据源配置对象为Map

### DIFF
--- a/sharding-jdbc-core/src/main/java/com/dangdang/ddframe/rdb/sharding/api/ShardingDataSource.java
+++ b/sharding-jdbc-core/src/main/java/com/dangdang/ddframe/rdb/sharding/api/ShardingDataSource.java
@@ -20,7 +20,7 @@ package com.dangdang.ddframe.rdb.sharding.api;
 import java.sql.Connection;
 import java.sql.DatabaseMetaData;
 import java.sql.SQLException;
-import java.util.Properties;
+import java.util.Map;
 
 import javax.sql.DataSource;
 
@@ -49,10 +49,10 @@ public class ShardingDataSource extends AbstractDataSourceAdapter {
     private final MetricsContext metricsContext;
     
     public ShardingDataSource(final ShardingRule shardingRule) {
-        this(shardingRule, new Properties());
+        this(shardingRule, null);
     }
     
-    public ShardingDataSource(final ShardingRule shardingRule, final Properties props) {
+    public ShardingDataSource(final ShardingRule shardingRule, final Map<String,Object> props) {
         this.shardingRule = shardingRule;
         databaseMetaData = getDatabaseMetaData();
         configuration = new ShardingConfiguration(props);

--- a/sharding-jdbc-core/src/main/java/com/dangdang/ddframe/rdb/sharding/api/config/ShardingConfiguration.java
+++ b/sharding-jdbc-core/src/main/java/com/dangdang/ddframe/rdb/sharding/api/config/ShardingConfiguration.java
@@ -17,20 +17,31 @@
 
 package com.dangdang.ddframe.rdb.sharding.api.config;
 
-import java.util.Properties;
-
-import lombok.RequiredArgsConstructor;
+import java.util.Collections;
+import java.util.Map;
 
 /**
  * 配置类.
  *
  * @author gaohongtao
  */
-@RequiredArgsConstructor
 public final class ShardingConfiguration {
     
-    private final Properties props;
-    
+    private  Map<String,Object> props;
+
+    public ShardingConfiguration() {
+        this.props= Collections.emptyMap();
+    }
+
+    public ShardingConfiguration(Map<String, Object> props) {
+        if(props == null){
+            this.props=Collections.emptyMap();
+        }else {
+            this.props = props;
+        }
+    }
+
+
     /**
      * 获取字符串类型的配置.
      * 
@@ -38,7 +49,11 @@ public final class ShardingConfiguration {
      * @return 配置值
      */
     public String getConfig(final ShardingConfigurationConstant key) {
-        return props.getProperty(key.getKey(), key.getDefaultValue());
+        Object value=props.get(key.getKey());
+        if(value==null){
+            return key.getDefaultValue();
+        }
+        return value.toString();
     }
     
     /**

--- a/sharding-jdbc-core/src/test/java/com/dangdang/ddframe/rdb/sharding/api/config/ShardingConfigurationTest.java
+++ b/sharding-jdbc-core/src/test/java/com/dangdang/ddframe/rdb/sharding/api/config/ShardingConfigurationTest.java
@@ -21,14 +21,15 @@ import static org.hamcrest.CoreMatchers.is;
 import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
 
-import java.util.Properties;
+import java.util.Map;
 
+import com.google.common.collect.Maps;
 import org.junit.Before;
 import org.junit.Test;
 
 public final class ShardingConfigurationTest {
     
-    private final Properties prop = new Properties();
+    private final Map<String,Object> prop = Maps.newHashMap();
     
     private final ShardingConfiguration shardingConfiguration = new ShardingConfiguration(prop);
     
@@ -41,11 +42,11 @@ public final class ShardingConfigurationTest {
     
     @Test
     public void assertGetConfigWithDefaultValue() {
-        assertThat(new ShardingConfiguration(new Properties()).getConfig(ShardingConfigurationConstant.METRICS_SECOND_PERIOD),
+        assertThat(new ShardingConfiguration().getConfig(ShardingConfigurationConstant.METRICS_SECOND_PERIOD),
                 is(ShardingConfigurationConstant.METRICS_SECOND_PERIOD.getDefaultValue()));
-        assertThat(new ShardingConfiguration(new Properties()).getConfig(ShardingConfigurationConstant.METRICS_ENABLE),
+        assertThat(new ShardingConfiguration().getConfig(ShardingConfigurationConstant.METRICS_ENABLE),
                 is(ShardingConfigurationConstant.METRICS_ENABLE.getDefaultValue()));
-        assertThat(new ShardingConfiguration(new Properties()).getConfig(ShardingConfigurationConstant.METRICS_PACKAGE_NAME),
+        assertThat(new ShardingConfiguration().getConfig(ShardingConfigurationConstant.METRICS_PACKAGE_NAME),
                 is(ShardingConfigurationConstant.METRICS_PACKAGE_NAME.getDefaultValue()));
     }
     


### PR DESCRIPTION
修改为Map的原因为：
1. Properties对象太重，这里没有必要使用这个
2. 修复bug
3. 减少了点点测试代码

bug描述：

比如配置`props.put("metrics.enable",true);`，这行代码不会正确的执行，具体见`java.util.Properties#getProperty(java.lang.String)`



