### PR TITLE
share connection between catalog

### DIFF
--- a/sharding-jdbc-core/src/main/java/com/dangdang/ddframe/rdb/sharding/jdbc/ShardingConnection.java
+++ b/sharding-jdbc-core/src/main/java/com/dangdang/ddframe/rdb/sharding/jdbc/ShardingConnection.java
@@ -34,6 +34,7 @@ import com.dangdang.ddframe.rdb.sharding.jdbc.adapter.AbstractConnectionAdapter;
 import com.dangdang.ddframe.rdb.sharding.metrics.MetricsContext;
 import com.google.common.base.Function;
 import com.google.common.base.Preconditions;
+import com.google.common.base.Strings;
 import com.google.common.collect.Collections2;
 import com.google.common.collect.Lists;
 import lombok.AccessLevel;
@@ -51,16 +52,24 @@ public final class ShardingConnection extends AbstractConnectionAdapter {
     
     @Getter(AccessLevel.PACKAGE)
     private final ShardingContext shardingContext;
-    
+
     private Map<String, Connection> connectionMap = new HashMap<>();
-    
+
+    private String catalog = "";
+
     /**
-     * 根据数据源名称获取相应的数据库连接.
+     * 根据数据源名称获取相应的数据库连接,并设置 Catalog 为 dataSourceName
      * 
      * @param dataSourceName 数据源名称
      * @return 数据库连接
      */
     public Connection getConnection(final String dataSourceName) throws SQLException {
+        Connection connection = getRawConnection(dataSourceName);
+        connection.setCatalog(dataSourceName);
+        return connection;
+    }
+
+    private Connection getRawConnection(final String dataSourceName) throws SQLException {
         if (connectionMap.containsKey(dataSourceName)) {
             return connectionMap.get(dataSourceName);
         }
@@ -71,7 +80,7 @@ public final class ShardingConnection extends AbstractConnectionAdapter {
         connectionMap.put(dataSourceName, connection);
         return connection;
     }
-    
+
     @Override
     public DatabaseMetaData getMetaData() throws SQLException {
         if (connectionMap.isEmpty()) {
@@ -132,7 +141,24 @@ public final class ShardingConnection extends AbstractConnectionAdapter {
         }
         return result;
     }
-    
+
+    @Override
+    public void setCatalog(String catalog) throws SQLException {
+        if (this.catalog.equals(catalog)) {
+            return;
+        }
+        Connection conn = getRawConnection(catalog);
+        Context metricsContext = MetricsContext.start("ShardingConnection-setCatalog", catalog);
+        conn.setCatalog(catalog);
+        MetricsContext.stop(metricsContext);
+        this.catalog = catalog;
+    }
+
+    @Override
+    public String getCatalog() throws SQLException {
+        return catalog;
+    }
+
     @Override
     public PreparedStatement prepareStatement(final String sql) throws SQLException {
         return new ShardingPreparedStatement(this, sql);

--- a/sharding-jdbc-core/src/main/java/com/dangdang/ddframe/rdb/sharding/jdbc/ShardingConnection.java
+++ b/sharding-jdbc-core/src/main/java/com/dangdang/ddframe/rdb/sharding/jdbc/ShardingConnection.java
@@ -34,7 +34,6 @@ import com.dangdang.ddframe.rdb.sharding.jdbc.adapter.AbstractConnectionAdapter;
 import com.dangdang.ddframe.rdb.sharding.metrics.MetricsContext;
 import com.google.common.base.Function;
 import com.google.common.base.Preconditions;
-import com.google.common.base.Strings;
 import com.google.common.collect.Collections2;
 import com.google.common.collect.Lists;
 import lombok.AccessLevel;

--- a/sharding-jdbc-core/src/main/java/com/dangdang/ddframe/rdb/sharding/jdbc/unsupported/AbstractUnsupportedOperationConnection.java
+++ b/sharding-jdbc-core/src/main/java/com/dangdang/ddframe/rdb/sharding/jdbc/unsupported/AbstractUnsupportedOperationConnection.java
@@ -88,16 +88,6 @@ public abstract class AbstractUnsupportedOperationConnection extends WrapperAdap
     }
     
     @Override
-    public final String getCatalog() throws SQLException {
-        throw new SQLFeatureNotSupportedException("getCatalog");
-    }
-    
-    @Override
-    public final void setCatalog(final String catalog) throws SQLException {
-        throw new SQLFeatureNotSupportedException("setCatalog");
-    }
-    
-    @Override
     public final String getSchema() throws SQLException {
         throw new SQLFeatureNotSupportedException("getSchema");
     }

--- a/sharding-jdbc-core/src/test/java/com/dangdang/ddframe/rdb/sharding/jdbc/unsupported/UnsupportedOperationConnectionTest.java
+++ b/sharding-jdbc-core/src/test/java/com/dangdang/ddframe/rdb/sharding/jdbc/unsupported/UnsupportedOperationConnectionTest.java
@@ -91,17 +91,7 @@ public final class UnsupportedOperationConnectionTest extends AbstractShardingDa
     public void assertAbort() throws SQLException {
         actual.abort(null);
     }
-    
-    @Test(expected = SQLFeatureNotSupportedException.class)
-    public void assertGetCatalog() throws SQLException {
-        actual.getCatalog();
-    }
-    
-    @Test(expected = SQLFeatureNotSupportedException.class)
-    public void assertSetCatalog() throws SQLException {
-        actual.setCatalog("");
-    }
-    
+
     @Test(expected = SQLFeatureNotSupportedException.class)
     public void assertGetSchema() throws SQLException {
         actual.getSchema();


### PR DESCRIPTION
setCatalog 场景是：
在设计分库的时候，为了以后方便扩展，会使用比较大的切片，比如拆分为 4096 个shard。但是初期的数据量并不会很大，比如用 16 台机器，每个机器跑1个数据库进程，每个进程放 256 个 db。按照现有的一个db一个连接的情况下，一个worker就要用掉数据库256个连接，随便起几十个worker，数据库的连接数就满了。

实现了 ShardConnection 的 `setCatalog` `getCatalog` 方法。

@terrymanu 根据 #27 做了调整。

H2 不支持 `setCatalog` 所以没有增加相关的测试