### PR TITLE
将AtomicInteger改为AtomicLong。多线程环境下，有可能出现count值大于数组size的情况，compareAndSe…

### DIFF
--- a/sharding-jdbc-core/src/main/java/com/dangdang/ddframe/rdb/sharding/api/strategy/slave/RoundRobinSlaveLoadBalanceStrategy.java
+++ b/sharding-jdbc-core/src/main/java/com/dangdang/ddframe/rdb/sharding/api/strategy/slave/RoundRobinSlaveLoadBalanceStrategy.java
@@ -20,7 +20,7 @@ package com.dangdang.ddframe.rdb.sharding.api.strategy.slave;
 import javax.sql.DataSource;
 import java.util.List;
 import java.util.concurrent.ConcurrentHashMap;
-import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicLong;
 
 /**
  * 轮询负载均衡策略.
@@ -28,14 +28,13 @@ import java.util.concurrent.atomic.AtomicInteger;
  * @author zhangliang
  */
 public final class RoundRobinSlaveLoadBalanceStrategy implements SlaveLoadBalanceStrategy {
-    
-    private static final ConcurrentHashMap<String, AtomicInteger> COUNT_MAP = new ConcurrentHashMap<>();
-    
+
+    private static final ConcurrentHashMap<String, AtomicLong> COUNT_MAP = new ConcurrentHashMap<>();
+
     @Override
     public DataSource getDataSource(final String name, final List<DataSource> slaveDataSources) {
-        AtomicInteger count = COUNT_MAP.containsKey(name) ? COUNT_MAP.get(name) : new AtomicInteger(0);
+        AtomicLong count = COUNT_MAP.containsKey(name) ? COUNT_MAP.get(name) : new AtomicLong(0);
         COUNT_MAP.putIfAbsent(name, count);
-        count.compareAndSet(slaveDataSources.size(), 0);
-        return slaveDataSources.get(count.getAndIncrement() % slaveDataSources.size());
+        return slaveDataSources.get((int) (count.getAndIncrement() % slaveDataSources.size()));
     }
 }


### PR DESCRIPTION
…t将无法归零，超过Integer最大值就出现负数，导致从数组中取值报错。