### PR TITLE
Fix unlimited increase count of metrics reporter thread

### DIFF
--- a/sharding-jdbc-core/src/main/java/com/dangdang/ddframe/rdb/sharding/metrics/MetricsContext.java
+++ b/sharding-jdbc-core/src/main/java/com/dangdang/ddframe/rdb/sharding/metrics/MetricsContext.java
@@ -17,37 +17,38 @@
 
 package com.dangdang.ddframe.rdb.sharding.metrics;
 
-import com.dangdang.ddframe.rdb.sharding.config.ShardingProperties;
 import com.codahale.metrics.MetricRegistry;
 import com.codahale.metrics.ScheduledReporter;
 import com.codahale.metrics.Slf4jReporter;
 import com.codahale.metrics.Timer;
+import com.dangdang.ddframe.rdb.sharding.config.ShardingProperties;
 import com.dangdang.ddframe.rdb.sharding.config.ShardingPropertiesConstant;
-import java.util.concurrent.TimeUnit;
+import lombok.AccessLevel;
+import lombok.NoArgsConstructor;
 import org.slf4j.LoggerFactory;
+
+import java.util.concurrent.TimeUnit;
 
 /**
  * 度量上下文持有者.
- *
+ * 
  * <p>
  * 多个ShardingDataSource使用静态度量上下文会造成数据污染, 所以将度量上下文对象绑定到ThreadLocal中.
  * </p>
- *
+ * 
  * @author gaohongtao
  * @author zhangliang
  */
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
 public final class MetricsContext {
-
-    private MetricsContext() {
-    }
-
+    
     private static final MetricRegistry METRIC_REGISTRY = new MetricRegistry();
     private static ScheduledReporter reporter = null;
     private static final Object LOCK = new Object();
-
+    
     /**
      * 初始化度量上下文持有者.
-     *
+     * 
      * @param shardingProperties Sharding-JDBC的配置属性
      */
     public static void init(final ShardingProperties shardingProperties) {
@@ -73,17 +74,18 @@ public final class MetricsContext {
             }
         }
     }
-
+    
     /**
      * 开始计时.
      *
      * @param name 度量目标名称
+     *
      * @return 计时上下文
      */
     public static Timer.Context start(final String name) {
-        return METRIC_REGISTRY.timer(MetricRegistry.name(name)).time();
+      return METRIC_REGISTRY.timer(MetricRegistry.name(name)).time();
     }
-
+    
     /**
      * 停止计时.
      *
@@ -94,11 +96,11 @@ public final class MetricsContext {
             context.stop();
         }
     }
-
+    
     /**
      * 清理数据.
      */
     public static void clear() {
-        // do nothing
+      // do nothing
     }
 }

--- a/sharding-jdbc-core/src/main/java/com/dangdang/ddframe/rdb/sharding/metrics/MetricsContext.java
+++ b/sharding-jdbc-core/src/main/java/com/dangdang/ddframe/rdb/sharding/metrics/MetricsContext.java
@@ -15,14 +15,14 @@
  * </p>
  */
 
-package com.ai.raptor.dal.metrics;
+package com.dangdang.ddframe.rdb.sharding.metrics;
 
-import com.ai.raptor.dal.config.ShardingProperties;
-import com.ai.raptor.dal.config.ShardingPropertiesConstant;
+import com.dangdang.ddframe.rdb.sharding.config.ShardingProperties;
 import com.codahale.metrics.MetricRegistry;
 import com.codahale.metrics.ScheduledReporter;
 import com.codahale.metrics.Slf4jReporter;
 import com.codahale.metrics.Timer;
+import com.dangdang.ddframe.rdb.sharding.config.ShardingPropertiesConstant;
 import java.util.concurrent.TimeUnit;
 import org.slf4j.LoggerFactory;
 
@@ -38,67 +38,67 @@ import org.slf4j.LoggerFactory;
  */
 public final class MetricsContext {
 
-  private MetricsContext() {
-  }
-
-  private static final MetricRegistry METRIC_REGISTRY = new MetricRegistry();
-  private static ScheduledReporter reporter = null;
-  private static final Object LOCK = new Object();
-
-  /**
-   * 初始化度量上下文持有者.
-   *
-   * @param shardingProperties Sharding-JDBC的配置属性
-   */
-  public static void init(final ShardingProperties shardingProperties) {
-    boolean metricsEnabled = shardingProperties.getValue(ShardingPropertiesConstant.METRICS_ENABLE);
-    if (!metricsEnabled) {
-      return;
+    private MetricsContext() {
     }
-    long period = shardingProperties
-        .getValue(ShardingPropertiesConstant.METRICS_MILLISECONDS_PERIOD);
-    String loggerName = shardingProperties.getValue(ShardingPropertiesConstant.METRICS_LOGGER_NAME);
-    // build a static reporter (only need one)
-    if (null == reporter) {
-      synchronized (LOCK) {
-        if (null == reporter) {
-          reporter = Slf4jReporter.forRegistry(METRIC_REGISTRY)
-              .outputTo(LoggerFactory.getLogger(loggerName))
-              .convertRatesTo(TimeUnit.SECONDS)
-              .convertDurationsTo(TimeUnit.MILLISECONDS)
-              .withLoggingLevel(Slf4jReporter.LoggingLevel.DEBUG)
-              .build();
-          reporter.start(period, TimeUnit.MILLISECONDS);
+
+    private static final MetricRegistry METRIC_REGISTRY = new MetricRegistry();
+    private static ScheduledReporter reporter = null;
+    private static final Object LOCK = new Object();
+
+    /**
+     * 初始化度量上下文持有者.
+     *
+     * @param shardingProperties Sharding-JDBC的配置属性
+     */
+    public static void init(final ShardingProperties shardingProperties) {
+        boolean metricsEnabled = shardingProperties.getValue(ShardingPropertiesConstant.METRICS_ENABLE);
+        if (!metricsEnabled) {
+            return;
         }
-      }
+        long period = shardingProperties
+            .getValue(ShardingPropertiesConstant.METRICS_MILLISECONDS_PERIOD);
+        String loggerName = shardingProperties.getValue(ShardingPropertiesConstant.METRICS_LOGGER_NAME);
+        // build a static reporter (only need one)
+        if (null == reporter) {
+            synchronized (LOCK) {
+                if (null == reporter) {
+                    reporter = Slf4jReporter.forRegistry(METRIC_REGISTRY)
+                        .outputTo(LoggerFactory.getLogger(loggerName))
+                        .convertRatesTo(TimeUnit.SECONDS)
+                        .convertDurationsTo(TimeUnit.MILLISECONDS)
+                        .withLoggingLevel(Slf4jReporter.LoggingLevel.DEBUG)
+                        .build();
+                    reporter.start(period, TimeUnit.MILLISECONDS);
+                }
+            }
+        }
     }
-  }
 
-  /**
-   * 开始计时.
-   *
-   * @param name 度量目标名称
-   * @return 计时上下文
-   */
-  public static Timer.Context start(final String name) {
-    return METRIC_REGISTRY.timer(MetricRegistry.name(name)).time();
-  }
-
-  /**
-   * 停止计时.
-   *
-   * @param context 计时上下文
-   */
-  public static void stop(final Timer.Context context) {
-    if (null != context) {
-      context.stop();
+    /**
+     * 开始计时.
+     *
+     * @param name 度量目标名称
+     * @return 计时上下文
+     */
+    public static Timer.Context start(final String name) {
+        return METRIC_REGISTRY.timer(MetricRegistry.name(name)).time();
     }
-  }
 
-  /**
-   * 清理数据.
-   */
-  public static void clear() {
-    // do nothing
-  }
+    /**
+     * 停止计时.
+     *
+     * @param context 计时上下文
+     */
+    public static void stop(final Timer.Context context) {
+        if (null != context) {
+            context.stop();
+        }
+    }
+
+    /**
+     * 清理数据.
+     */
+    public static void clear() {
+        // do nothing
+    }
 }


### PR DESCRIPTION
问题描述：
开启metrics统计之后，出现线程数激增，最终导致服务器宕机。

问题发现：
通过visual vm监控发现，每次请求都会新增一个reporter线程。

问题分析：
sjdbc使用的ScheduledReporter中使用ScheduledExecutorService来调度执行报告任务，并且com.ai.raptor.dal.metrics.MetricsContext#init方法每次请求都会构建一个reporter，即SES，最终导致线程数随着请求数量不断增加。

解决方案，启动有限个Reporter线程。

至于MetricsContext中提到的数据污染问题，我的思考是：
1、如果要从ShardingDataSource的维度来度量的话，那么只需创建DataSource对应的度量下文即可，并且启动的Reporter线程也只跟DataSource的数量有关，不会出现线程爆炸式增长的风险。
2、一个应用ShardingDataSource的数量可以是多个，但是常用的分库场景是ER分库，对于物理模型完全一样的ER分库就更没必要创建多个度量上下文。

反正最终的度量是一个全局的数据输出才对，像现在的做法只统计一次请求的数据有点片面了，参考价值少了点。

度量报告范例：
````
3/8/17 11:58:01 AM =============================================================

-- Timers ----------------------------------------------------------------------
Parse SQL
             count = 12
         mean rate = 0.40 calls/second
     1-minute rate = 0.30 calls/second
     5-minute rate = 0.22 calls/second
    15-minute rate = 0.21 calls/second
               min = 0.48 milliseconds
               max = 477.85 milliseconds
              mean = 32.69 milliseconds
            stddev = 119.05 milliseconds
            median = 0.79 milliseconds
              75% <= 1.04 milliseconds
              95% <= 477.85 milliseconds
              98% <= 477.85 milliseconds
              99% <= 477.85 milliseconds
            99.9% <= 477.85 milliseconds
Route SQL
             count = 12
         mean rate = 0.41 calls/second
     1-minute rate = 0.30 calls/second
     5-minute rate = 0.22 calls/second
    15-minute rate = 0.21 calls/second
               min = 0.07 milliseconds
               max = 27.35 milliseconds
              mean = 1.92 milliseconds
            stddev = 6.80 milliseconds
            median = 0.11 milliseconds
              75% <= 0.12 milliseconds
              95% <= 27.35 milliseconds
              98% <= 27.35 milliseconds
              99% <= 27.35 milliseconds
            99.9% <= 27.35 milliseconds
ShardingPreparedStatement-execute
             count = 24
         mean rate = 0.95 calls/second
     1-minute rate = 0.58 calls/second
     5-minute rate = 0.44 calls/second
    15-minute rate = 0.42 calls/second
               min = 2.15 milliseconds
               max = 63.31 milliseconds
              mean = 7.17 milliseconds
            stddev = 15.47 milliseconds
            median = 2.79 milliseconds
              75% <= 3.65 milliseconds
              95% <= 63.22 milliseconds
              98% <= 63.31 milliseconds
              99% <= 63.31 milliseconds
            99.9% <= 63.31 milliseconds
````