### PR TITLE
Fix issue#328：处理 ShardingConnection commit 异常

### DIFF
--- a/sharding-jdbc-core/src/main/java/com/dangdang/ddframe/rdb/sharding/jdbc/adapter/AbstractConnectionAdapter.java
+++ b/sharding-jdbc-core/src/main/java/com/dangdang/ddframe/rdb/sharding/jdbc/adapter/AbstractConnectionAdapter.java
@@ -63,9 +63,15 @@ public abstract class AbstractConnectionAdapter extends AbstractUnsupportedOpera
     
     @Override
     public final void commit() throws SQLException {
+        Collection<SQLException> exceptions = new LinkedList<>();
         for (Connection each : getConnections()) {
-            each.commit();
+            try {
+                each.commit();
+            } catch (final SQLException ex) {
+                exceptions.add(ex);
+            }
         }
+        throwSQLExceptionIfNecessary(exceptions);
     }
     
     @Override


### PR DESCRIPTION
Fixes #328.

- ShardingConnection commit 时，持有的 Connection commit 异常时，后面的 Connection 无法提交
